### PR TITLE
Use a <form> for the API key so it's saved by password managers

### DIFF
--- a/bugzilla.js
+++ b/bugzilla.js
@@ -65,6 +65,7 @@ $(function() {
           if ($("#api_key").val() == "") {
             return;
           }
+          $("#api_key_container").submit();
           gAPIKey = $("#api_key").val();
           $(this).dialog("close");
         },

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <link rel="stylesheet" type="text/css" href="jquery-ui-1.11.4/jquery-ui.min.css">
   <link rel="stylesheet" type="text/css" href="index.css">
 <body>
-  <div id="api_key_container">
+  <form id="api_key_container" action="javascript:void(0)">
     <input type="password" placeholder="Bugzilla API Key" id="api_key" size="20">
     <a href="https://bugzilla.mozilla.org/userprefs.cgi?tab=apikey" target="_blank">(help)</a>
-  </div>
+  </form>
   <section id="tabs">
     <ul>
       <li><a href="#intro">Introduction</a></li>


### PR DESCRIPTION
I tested that this works with Firefox's password manager but since it's using a form submit event it should work with others too.